### PR TITLE
Replace variables in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,23 @@ headers:
     - application/json
   Authorization:
     - Bearer ${your-token-here}
+variables:
+  companyId: 123456
 ```
 
 And then you can just call the api like the following:
 
 ```bash
-$ go-http-cli +family people
+$ go-http-cli +family '${companyId}/people'
 
-GET https://family-menu.herokuapp.com/api/v1/people
+GET https://family-menu.herokuapp.com/api/v1/123456/people
 Content-Type: application/json
 Authorization: Bearer your-token-here
 ```
 
 The path can be a relative path or an absolute path. The algorithm is very simple, it just concatenates
-`baseURL` with `URL` making sure only one `/` will exist between the two.
+`baseURL` with `URL` making sure only one `/` will exist between the two. It will also use the variables
+set in the configuration file to replace the ones in the URL.
 
 ## Examples
 

--- a/bin/fmtCompare.sh
+++ b/bin/fmtCompare.sh
@@ -15,7 +15,7 @@ output_dir=$build_dir/fmt
 rm -Rf $output_dir/*
 
 # Ensure all directories exist
-dirs=("$build_dir" "$output_dir" "$output_dir/config" "$output_dir/config/yaml" "$output_dir/strings")
+dirs=("$build_dir" "$output_dir" "$output_dir/config" "$output_dir/config/yaml" "$output_dir/strings" "$output_dir/request")
 for dir in "${dirs[@]}"; do
   if [ ! -d $dir ]; then
     mkdir $dir
@@ -32,6 +32,7 @@ diff $output_dir/main.go main.go
 diff -r $output_dir/config/ config/
 diff -r $output_dir/config/yaml config/yaml
 diff -r $output_dir/strings/ strings/
+diff -r $output_dir/request/ request/
 
 rm -Rf $output_dir
 

--- a/bin/fmtCompare.sh
+++ b/bin/fmtCompare.sh
@@ -15,7 +15,7 @@ output_dir=$build_dir/fmt
 rm -Rf $output_dir/*
 
 # Ensure all directories exist
-dirs=("$build_dir" "$output_dir" "$output_dir/config" "$output_dir/config/yaml")
+dirs=("$build_dir" "$output_dir" "$output_dir/config" "$output_dir/config/yaml" "$output_dir/strings")
 for dir in "${dirs[@]}"; do
   if [ ! -d $dir ]; then
     mkdir $dir
@@ -30,6 +30,8 @@ done
 # Compare files
 diff $output_dir/main.go main.go
 diff -r $output_dir/config/ config/
+diff -r $output_dir/config/yaml config/yaml
+diff -r $output_dir/strings/ strings/
 
 rm -Rf $output_dir
 

--- a/config/command_line_configuration.go
+++ b/config/command_line_configuration.go
@@ -30,7 +30,7 @@ type commandLineConfiguration struct {
 	method             string
 	profiles           []string
 	url                string
-	variables          map[string][]string
+	variables          map[string]string
 }
 
 func (conf commandLineConfiguration) BaseURL() string {
@@ -53,11 +53,11 @@ func (conf commandLineConfiguration) URL() string {
 	return conf.url
 }
 
-func (conf commandLineConfiguration) Variables() map[string][]string {
+func (conf commandLineConfiguration) Variables() map[string]string {
 	return conf.variables
 }
 
-func parseValues(headers keyValuePair) (map[string][]string, error) {
+func parseMultiValues(headers keyValuePair) (map[string][]string, error) {
 	result := make(map[string][]string)
 
 	for _, kv := range headers {
@@ -74,6 +74,24 @@ func parseValues(headers keyValuePair) (map[string][]string, error) {
 		} else {
 			result[key] = []string{value}
 		}
+	}
+
+	return result, nil
+}
+
+func parseValues(headers keyValuePair) (map[string]string, error) {
+	result := make(map[string]string)
+
+	for _, kv := range headers {
+		s := strings.Split(kv, "=")
+		if len(s) != 2 {
+			return result, errors.New("Error while parsing key value pair '" + kv + "'\nShould be an '=' separated key/value, e.g.: Content-type=application/x-www-form-urlencoded")
+		}
+
+		key := s[0]
+		value := s[1]
+
+		result[key] = value
 	}
 
 	return result, nil
@@ -135,7 +153,7 @@ func parseCommandLine(args []string) (*commandLineConfiguration, error) {
 		return result, urlError
 	}
 
-	parsedHeaders, headerError := parseValues(headers)
+	parsedHeaders, headerError := parseMultiValues(headers)
 	result.headers = parsedHeaders
 
 	if headerError != nil {

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -23,7 +23,7 @@ type Configuration interface {
 	Body() string
 	Method() string
 	URL() string
-	Variables() map[string][]string
+	Variables() map[string]string
 }
 
 func hasYAMLExtension(path string) bool {

--- a/config/hierarchical_configuration.go
+++ b/config/hierarchical_configuration.go
@@ -54,8 +54,8 @@ func (conf hierarchicalConfigurationFormat) URL() string {
 	return result
 }
 
-func (conf hierarchicalConfigurationFormat) Variables() map[string][]string {
-	result := make(map[string][]string)
+func (conf hierarchicalConfigurationFormat) Variables() map[string]string {
+	result := make(map[string]string)
 	for _, subConfig := range conf.configurations {
 		for k, v := range subConfig.Variables() {
 			result[k] = v

--- a/config/hierarchical_configuration_test.go
+++ b/config/hierarchical_configuration_test.go
@@ -12,7 +12,7 @@ type testConfiguration struct {
 	body      string
 	method    string
 	url       string
-	variables map[string][]string
+	variables map[string]string
 }
 
 func (conf testConfiguration) BaseURL() string {
@@ -35,7 +35,7 @@ func (conf testConfiguration) URL() string {
 	return conf.url
 }
 
-func (conf testConfiguration) Variables() map[string][]string {
+func (conf testConfiguration) Variables() map[string]string {
 	return conf.variables
 }
 
@@ -86,14 +86,14 @@ func testOverrideHeaders(t *testing.T) {
 func testOverrideVariables(t *testing.T) {
 	variableName := "someVariable"
 
-	config1Variables := make(map[string][]string)
-	config1Variables[variableName] = []string{"value1"}
+	config1Variables := make(map[string]string)
+	config1Variables[variableName] = "value1"
 	config1 := testConfiguration{
 		variables: config1Variables,
 	}
 
-	config2Variables := make(map[string][]string)
-	config2Variables[variableName] = []string{"value2"}
+	config2Variables := make(map[string]string)
+	config2Variables[variableName] = "value2"
 	config2 := testConfiguration{
 		variables: config2Variables,
 	}
@@ -102,5 +102,5 @@ func testOverrideVariables(t *testing.T) {
 		configurations: []Configuration{config1, config2},
 	}
 
-	assert.Equal(t, "value2", underTest.Variables()[variableName][0])
+	assert.Equal(t, "value2", underTest.Variables()[variableName])
 }

--- a/config/yaml/yaml_configuration.go
+++ b/config/yaml/yaml_configuration.go
@@ -69,10 +69,10 @@ func (conf FileConfiguration) URL() string {
 }
 
 // Variables that were added to the configuration file
-func (conf FileConfiguration) Variables() map[string][]string {
-	result := make(map[string][]string)
+func (conf FileConfiguration) Variables() map[string]string {
+	result := make(map[string]string)
 	for name, values := range conf.parsedYaml.Variables {
-		result[name] = values
+		result[name] = values[0]
 	}
 	return result
 }

--- a/config/yaml/yaml_configuration_test.go
+++ b/config/yaml/yaml_configuration_test.go
@@ -77,7 +77,7 @@ func assertParsedHeaders(t *testing.T, err error, parsedConfiguration *FileConfi
 func assertParsedVariables(t *testing.T, err error, parsedConfiguration *FileConfiguration) {
 	assertNoError(t, err)
 	assert.Equal(t, len(parsedConfiguration.Variables()), 1, "Should have parsed one header")
-	assert.Equal(t, parsedConfiguration.Variables()[testVariableName], []string{testVariableValue}, "Should parse variable value correctly")
+	assert.Equal(t, parsedConfiguration.Variables()[testVariableName], testVariableValue, "Should parse variable value correctly")
 }
 
 func writeToFile(fileName string, content string) *os.File {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/visola/go-http-cli/config"
+	"github.com/visola/go-http-cli/request"
 )
 
 type bodyBuffer struct {
@@ -28,18 +29,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	url := configuration.URL()
-	if baseURL := configuration.BaseURL(); baseURL != "" {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL = baseURL + "/"
-		}
-
-		if strings.HasPrefix(url, "/") {
-			url = url[1:]
-		}
-
-		url = baseURL + url
-	}
+	url := request.ParseURL(configuration.BaseURL(), configuration.URL(), configuration.Variables())
 
 	color.Green("\n%s %s\n", configuration.Method(), url)
 	req, reqErr := http.NewRequest(configuration.Method(), url, nil)

--- a/request/parse_url.go
+++ b/request/parse_url.go
@@ -1,0 +1,25 @@
+package request
+
+import (
+	"strings"
+
+	myStrings "github.com/visola/go-http-cli/strings"
+)
+
+// ParseURL parses the configuration to generate the final URL that the request will be sent to.
+func ParseURL(base string, path string, variables map[string]string) string {
+	url := path
+	if base != "" {
+		if !strings.HasSuffix(base, "/") {
+			base = base + "/"
+		}
+
+		if strings.HasPrefix(path, "/") {
+			path = path[1:]
+		}
+
+		url = base + path
+	}
+
+	return myStrings.ParseExpression(url, variables)
+}

--- a/request/parse_url_test.go
+++ b/request/parse_url_test.go
@@ -1,0 +1,15 @@
+package request
+
+import (
+	"fmt"
+)
+
+func ExampleParseURL() {
+	base := "http://localhost:3000/api/v1"
+	url := "/${companyId}/contacts"
+	context := map[string]string{
+		"companyId": "123456",
+	}
+	fmt.Println(ParseURL(base, url, context))
+	// Output: http://localhost:3000/api/v1/123456/contacts
+}

--- a/strings/variable_parser.go
+++ b/strings/variable_parser.go
@@ -1,0 +1,16 @@
+package strings
+
+import (
+	"strings"
+)
+
+// ParseExpression parses a string template with variables in the format ${myVariable} and uses
+// values from the context map to replace them. The resulting string is the template string with
+// replaced values.
+func ParseExpression(template string, context map[string]string) string {
+	result := template
+	for key, value := range context {
+		result = strings.Replace(result, "${"+key+"}", value, -1)
+	}
+	return result
+}

--- a/strings/variable_parser_test.go
+++ b/strings/variable_parser_test.go
@@ -1,0 +1,17 @@
+package strings
+
+import (
+	"fmt"
+)
+
+func ExampleParseExpression() {
+	template := "${name} was born in ${dob} in ${location}. ${name} hair is ${hairColor}."
+	context := map[string]string{
+		"dob":       "01/08/1956",
+		"hairColor": "black",
+		"location":  "Japan",
+		"name":      "John",
+	}
+	fmt.Println(ParseExpression(template, context))
+	// Output: John was born in 01/08/1956 in Japan. John hair is black.
+}


### PR DESCRIPTION
Fixes #16 

- Refactor variables because they can only have one value
- Add a simple variable replacement algorithm
- Use the algorithm to replace variables in URL