### PR TITLE
replace http verbs with builtin http package verbs

### DIFF
--- a/cli/command_line_options_test.go
+++ b/cli/command_line_options_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,7 @@ import (
 var (
 	testBaseURL = "http://www.test.com"
 	testData    = "Some Data"
-	testMethod  = "POST"
+	testMethod  = http.MethodPost
 	testHeader  = "SomeHeader"
 	testValue   = "SomeValue"
 	testURL     = "/somePath"

--- a/daemon/client.go
+++ b/daemon/client.go
@@ -49,10 +49,10 @@ func Handshake() (int8, error) {
 }
 
 func callDaemon(path string, data string, unmarshalTo interface{}) error {
-	method := "POST"
+	method := http.MethodPost
 
 	if data == "" {
-		method = "GET"
+		method = http.MethodGet
 	}
 
 	url := "http://localhost:" + string(DaemonPort) + path

--- a/request/builder.go
+++ b/request/builder.go
@@ -42,9 +42,9 @@ func configureRequest(unconfiguredRequest Request, profiles []profile.Options, p
 
 	if method == "" {
 		if unconfiguredRequest.Body == "" {
-			method = "GET"
+			method = http.MethodGet
 		} else {
-			method = "POST"
+			method = http.MethodPost
 		}
 	}
 

--- a/request/builder_test.go
+++ b/request/builder_test.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"net/http"
 	"net/http/httputil"
 	"testing"
 
@@ -13,7 +14,7 @@ func TestBuildRequest(t *testing.T) {
 		Headers: map[string][]string{
 			"Content-Type": {"application/json"},
 		},
-		Method: "POST",
+		Method: http.MethodPost,
 		URL:    "http://www.someserver.com/{companyId}/employee",
 	}
 

--- a/request/executor_test.go
+++ b/request/executor_test.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,7 @@ import (
 
 func TestExecuteRequest(t *testing.T) {
 	request := Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    "https://www.google.com",
 	}
 

--- a/request/models_test.go
+++ b/request/models_test.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func TestMashalUnmarshalExecutedRequestResponse(t *testing.T) {
 		Headers: map[string][]string{
 			"Content-Type": {"application/json"},
 		},
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    "http://www.google.com",
 	}
 


### PR DESCRIPTION
Resolves #48

[`net/http` has builtin constants](https://golang.org/src/net/http/method.go) which should be used instead of `"GET"` or `"POST"`

cc: @visola 
  