### PR TITLE
Change request configuration format in profiles

### DIFF
--- a/profile/yaml_profile_format.go
+++ b/profile/yaml_profile_format.go
@@ -5,7 +5,7 @@ type yamlProfileFormat struct {
 	BaseURL   string `yaml:"baseURL"`
 	Headers   map[string]arrayOrString
 	Variables map[string]string
-	Requests  []requestConfiguration
+	Requests  map[string]requestConfiguration
 }
 
 // Used to unmarshal request options from yaml files
@@ -13,7 +13,6 @@ type requestConfiguration struct {
 	Body    string
 	Headers map[string]arrayOrString
 	Method  string
-	Name    string
 	URL     string
 }
 
@@ -26,10 +25,10 @@ func (loadedProfile yamlProfileFormat) toOptions() *Options {
 	}
 }
 
-func toMapOfRequestOptions(requestConfigurations []requestConfiguration) map[string]RequestOptions {
+func toMapOfRequestOptions(requestConfigurations map[string]requestConfiguration) map[string]RequestOptions {
 	result := make(map[string]RequestOptions)
-	for _, requestConfiguration := range requestConfigurations {
-		result[requestConfiguration.Name] = RequestOptions{
+	for name, requestConfiguration := range requestConfigurations {
+		result[name] = RequestOptions{
 			Body:    requestConfiguration.Body,
 			Headers: toMapOfArrayOfStrings(requestConfiguration.Headers),
 			Method:  requestConfiguration.Method,


### PR DESCRIPTION
This changes the request configuration format inside profiles from an array of requests with a name attribute in them to be a map where the key is the name of the request configuration.

From this:
```yaml
requests:
  - name: myRequest
    url: /some/path
```

To this:
```yaml
requests:
  myRequest:
    url: /some/path
```