### PR TITLE
Load request data correctly

### DIFF
--- a/profile/load_request.go
+++ b/profile/load_request.go
@@ -5,25 +5,25 @@ import (
 )
 
 // LoadRequestOptions loads request configurations from the profile names passed in. It returns
-// an error if it doesn't find a request configuration with the specified name.
+// an error if it doesn't find a request configuration with the specified name. It will return the
+// last request options found, if the same name is found in multiple profiles.
 func LoadRequestOptions(requestNameToFind string, profiles []string) (*RequestOptions, error) {
+	result := make([]RequestOptions, 0)
 	for _, profileName := range profiles {
 		profileOptions, err := LoadProfile(profileName)
 		if err != nil {
 			return nil, err
 		}
 
-		var result *RequestOptions
 		for requestName, requestConfiguration := range profileOptions.RequestOptions {
 			if requestNameToFind == requestName {
-				result = &requestConfiguration
+				result = append(result, requestConfiguration)
 			}
 		}
+	}
 
-		// Return the last one found
-		if result != nil {
-			return result, nil
-		}
+	if len(result) > 0 {
+		return &result[len(result)-1], nil
 	}
 
 	return nil, fmt.Errorf("Request '%s' not found in profiles '%s'", requestNameToFind, profiles)

--- a/profile/load_request_test.go
+++ b/profile/load_request_test.go
@@ -1,0 +1,65 @@
+package profile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadRequestOptions(t *testing.T) {
+	t.Run("Loads the correct request", testLoadsCorrectRequest)
+	t.Run("Returns error if request is not found", testErrorOnRequestNotFound)
+}
+
+func testLoadsCorrectRequest(t *testing.T) {
+	tempProfilesDir := setupTestProfilesDir()
+
+	profileName := "myProfile"
+	profileContent := "requests:\n  myRequest:\n    url: some/path\n  anotherRequest:\n    url: another/path\n"
+	createProfile(profileName, profileContent, tempProfilesDir)
+
+	request, requestErr := LoadRequestOptions("myRequest", []string{profileName})
+
+	assert.Nil(t, requestErr, "Should load request correctly")
+	if requestErr != nil {
+		panic(requestErr)
+	}
+
+	assert.Equal(t, "some/path", request.URL, "Should load the correct URL")
+}
+
+func testErrorOnRequestNotFound(t *testing.T) {
+	tempProfilesDir := setupTestProfilesDir()
+
+	profileName := "myProfile"
+	profileContent := "requests:\n  myRequest:\n    url: some/path\n"
+	createProfile(profileName, profileContent, tempProfilesDir)
+
+	_, requestErr := LoadRequestOptions("anotherRequest", []string{profileName})
+
+	assert.NotNil(t, requestErr, "Should fail to load if request name not found")
+}
+
+func createProfile(profileName string, profileContent string, profilesDir string) {
+	profileFile, err := os.Create(fmt.Sprintf("%s/%s.yml", profilesDir, profileName))
+	if err != nil {
+		panic(err)
+	}
+
+	defer profileFile.Close()
+
+	profileFile.WriteString(profileContent)
+}
+
+func setupTestProfilesDir() string {
+	dir, err := ioutil.TempDir("", "profiles")
+	if err != nil {
+		panic(err)
+	}
+
+	os.Setenv(profilesDirEnvVariable, dir)
+	return dir
+}

--- a/profile/profiles_dir.go
+++ b/profile/profiles_dir.go
@@ -5,9 +5,11 @@ import (
 	"os/user"
 )
 
+const profilesDirEnvVariable = "GO_HTTP_PROFILES"
+
 // GetProfilesDir return the directory where profiles are stored
 func GetProfilesDir() (string, error) {
-	profilesDir := os.Getenv("GO_HTTP_PROFILES")
+	profilesDir := os.Getenv(profilesDirEnvVariable)
 	if profilesDir == "" {
 		user, err := user.Current()
 		if err != nil {


### PR DESCRIPTION
The pointer manipulation was causing it to load the wrong request data, even if the `if` wasn't being executed. Not sure why and don't have time to investigate now. This change fixes it. Also added some tests to make sure it works correctly.