### PR TITLE
Make daemon respond with a wrapper object that contains error message

### DIFF
--- a/binaries/http/main.go
+++ b/binaries/http/main.go
@@ -21,15 +21,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	requestResponses, requestError := daemon.ExecuteRequest(options)
+	requestExecution, requestError := daemon.ExecuteRequest(options)
 
 	if requestError != nil {
 		color.Red("Error while executing request: %s", requestError)
 		os.Exit(10)
 	}
 
-	for _, requestResponse := range requestResponses {
+	for _, requestResponse := range requestExecution.RequestResponses {
 		output.PrintRequest(requestResponse.Request)
 		output.PrintResponse(requestResponse.Response)
+	}
+
+	if requestExecution.ErrorMessage != "" {
+		color.Red("Error while executing request: %s", requestExecution.ErrorMessage)
+		os.Exit(20)
 	}
 }

--- a/daemon/client.go
+++ b/daemon/client.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/visola/go-http-cli/cli"
 	"github.com/visola/go-http-cli/ioutil"
-	"github.com/visola/go-http-cli/request"
 )
 
 // ExecuteRequest request the daemon to execute a request
-func ExecuteRequest(commandLineOptions *cli.CommandLineOptions) ([]request.ExecutedRequestResponse, error) {
+func ExecuteRequest(commandLineOptions *cli.CommandLineOptions) (*RequestExecution, error) {
 	daemonRequest := &Request{
 		Body:        commandLineOptions.Body,
 		Headers:     commandLineOptions.Headers,
@@ -27,13 +26,13 @@ func ExecuteRequest(commandLineOptions *cli.CommandLineOptions) ([]request.Execu
 		return nil, marshalError
 	}
 
-	var requestResponses []request.ExecutedRequestResponse
+	var requestExecution RequestExecution
 
-	if callDaemonError := callDaemon("/request", string(dataAsBytes), &requestResponses); callDaemonError != nil {
+	if callDaemonError := callDaemon("/request", string(dataAsBytes), &requestExecution); callDaemonError != nil {
 		return nil, callDaemonError
 	}
 
-	return requestResponses, nil
+	return &requestExecution, nil
 }
 
 // Handshake connects and sends a handshake request to the daemon. Return the version of the daemon

--- a/daemon/models.go
+++ b/daemon/models.go
@@ -1,7 +1,15 @@
 package daemon
 
+import "github.com/visola/go-http-cli/request"
+
 // HandshakeResponse is the response sent by the daemon when someone is checking if it's up.
 type HandshakeResponse struct {
 	MajorVersion int8
 	MinorVersion int8
+}
+
+// RequestExecution is the response from the daemon when executing a request.
+type RequestExecution struct {
+	RequestResponses []request.ExecutedRequestResponse
+	ErrorMessage     string
 }


### PR DESCRIPTION
Fixes #54.

When an error happened while executing a request on the daemon side, it would just return a 500 and blow up. Now it wraps error messages and request/response pairs in a struct and pass them back gracefully to the client. This means that the client now knows what happened on the daemon side.

Before trying to execute a request that doesn't exist in a profile would panic as the following:
```
$ http +eb-dev2 @something
panic: Daemon responded with unexpected status code: 500 - 500 Internal Server Error
URL: http://localhost:4321/request, Method: POST

goroutine 1 [running]:
github.com/visola/go-http-cli/daemon.callDaemon(0x12d5463, 0x8, 0xc420154070, 0x6d, 0x125c2c0, 0xc42014c2a0, 0x0, 0xc420156060)
	/Users/vinicius.isola/git/go-workspace/src/github.com/visola/go-http-cli/daemon/client.go:78 +0x5ca
github.com/visola/go-http-cli/daemon.ExecuteRequest(0xc4201620e0, 0x2, 0x2, 0xc4201620e0, 0x0, 0x0)
	/Users/vinicius.isola/git/go-workspace/src/github.com/visola/go-http-cli/daemon/client.go:32 +0x208
main.main()
	/Users/vinicius.isola/git/go-workspace/src/github.com/visola/go-http-cli/binaries/http/main.go:24 +0x128
```

Now, the daemon will gracefully pass the message back and the client has a chance to do something with it:
```
$ http +eb-dev2 @something
Error while executing request: Request 'something' not found in profiles '[eb-dev2]'
```