### PR TITLE
Add Values to configured requests in profiles

### DIFF
--- a/profile/request_options.go
+++ b/profile/request_options.go
@@ -7,4 +7,5 @@ type RequestOptions struct {
 	Headers      map[string][]string
 	Method       string
 	URL          string
+	Values       map[string][]string
 }

--- a/profile/yaml_profile_format.go
+++ b/profile/yaml_profile_format.go
@@ -29,6 +29,7 @@ type requestConfiguration struct {
 	Headers      map[string]arrayOrString
 	Method       string
 	URL          string
+	Values       map[string]arrayOrString
 }
 
 func (loadedProfile yamlProfileFormat) toOptions() (*Options, error) {
@@ -78,6 +79,7 @@ func toMapOfRequestOptions(requestConfigurations map[string]requestConfiguration
 			Headers:      toMapOfArrayOfStrings(requestConfiguration.Headers),
 			Method:       requestConfiguration.Method,
 			URL:          requestConfiguration.URL,
+			Values:       toMapOfArrayOfStrings(requestConfiguration.Values),
 		}
 	}
 

--- a/request/builder.go
+++ b/request/builder.go
@@ -220,6 +220,7 @@ func mergeRequests(unconfiguredRequest Request, requestOptions profile.RequestOp
 		Headers: requestOptions.Headers,
 		Method:  requestOptions.Method,
 		URL:     requestOptions.URL,
+		Values:  requestOptions.Values,
 	}
 
 	newRequest := Request{}


### PR DESCRIPTION
Finishes the last part of #75 adding `values` attribute to `requests` inside profiles.