### PR TITLE
Add post-process hook and JS framework

### DIFF
--- a/binaries/go-http-daemon/main.go
+++ b/binaries/go-http-daemon/main.go
@@ -79,6 +79,12 @@ func executeRequest(c echo.Context) error {
 		requestExecution.ErrorMessage = responseErr.Error()
 	}
 
+	postProcessError := request.PostProcess(executionOptions, requestResponses, responseErr)
+	if postProcessError != nil {
+		log.Error(postProcessError)
+		requestExecution.PostProcessError = postProcessError.Error()
+	}
+
 	c.JSON(http.StatusOK, requestExecution)
 	return nil
 }

--- a/binaries/http/main.go
+++ b/binaries/http/main.go
@@ -25,11 +25,12 @@ func main() {
 	}
 
 	executionOptions := request.ExecutionOptions{
-		FileToUpload:   options.FileToUpload,
-		FollowLocation: options.FollowLocation,
-		MaxRedirect:    options.MaxRedirect,
-		ProfileNames:   options.Profiles,
-		RequestName:    options.RequestName,
+		FileToUpload:    options.FileToUpload,
+		FollowLocation:  options.FollowLocation,
+		MaxRedirect:     options.MaxRedirect,
+		PostProcessFile: options.PostProcessFile,
+		ProfileNames:    options.Profiles,
+		RequestName:     options.RequestName,
 		Request: request.Request{
 			Body:    options.Body,
 			Headers: options.Headers,
@@ -62,5 +63,10 @@ func main() {
 	if requestExecution.ErrorMessage != "" {
 		color.Red("Error while executing request: %s", requestExecution.ErrorMessage)
 		os.Exit(20)
+	}
+
+	if requestExecution.PostProcessError != "" {
+		color.Red("Error post processing request: %s", requestExecution.PostProcessError)
+		os.Exit(30)
 	}
 }

--- a/cli/command_line_options.go
+++ b/cli/command_line_options.go
@@ -11,18 +11,19 @@ import (
 
 // CommandLineOptions stores information that was requested by the user from the CLI.
 type CommandLineOptions struct {
-	Body           string
-	Headers        map[string][]string
-	FollowLocation bool
-	FileToUpload   string
-	MaxRedirect    int
-	Method         string
-	OutputFile     string
-	Profiles       []string
-	RequestName    string
-	URL            string
-	Values         map[string][]string
-	Variables      map[string]string
+	Body            string
+	Headers         map[string][]string
+	FollowLocation  bool
+	FileToUpload    string
+	MaxRedirect     int
+	Method          string
+	OutputFile      string
+	PostProcessFile string
+	Profiles        []string
+	RequestName     string
+	URL             string
+	Values          map[string][]string
+	Variables       map[string]string
 }
 
 type keyValuePair []string
@@ -42,7 +43,7 @@ func (i *keyValuePair) Type() string {
 
 // ParseCommandLineOptions parses the arguments received on the command line and generate a basic configuration.
 func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
-	var body, fileToUpload, method, outputFile string
+	var body, fileToUpload, method, outputFile, postProcessFile string
 	var configPaths, headers, variables keyValuePair
 	var followLocation bool
 
@@ -55,6 +56,7 @@ func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
 	maxRedirect := commandLine.Int("max-redirs", 50, "Maximum number of redirects to follow")
 	commandLine.StringVarP(&method, "method", "X", "", "HTTP method to be used")
 	commandLine.StringVarP(&outputFile, "output", "o", "", "File to save the response")
+	commandLine.StringVarP(&postProcessFile, "post-process", "", "", "Javascript file to post process the request/response")
 	commandLine.StringVarP(&fileToUpload, "upload-file", "T", "", "Path to the file to be uploaded")
 	commandLine.VarP(&variables, "variable", "V", "Variables to be used on substitutions")
 
@@ -68,6 +70,7 @@ func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
 	result.MaxRedirect = *maxRedirect
 	result.Method = method
 	result.OutputFile = outputFile
+	result.PostProcessFile = postProcessFile
 
 	url, requestName, profiles, values, urlError := parseArgs(commandLine.Args())
 	result.Profiles = profiles

--- a/daemon/models.go
+++ b/daemon/models.go
@@ -12,4 +12,5 @@ type HandshakeResponse struct {
 type RequestExecution struct {
 	RequestResponses []request.ExecutedRequestResponse
 	ErrorMessage     string
+	PostProcessError string
 }

--- a/request/models.go
+++ b/request/models.go
@@ -64,11 +64,12 @@ type ExecutedRequestResponse struct {
 
 // ExecutionOptions represent the options to be passed for the request executor.
 type ExecutionOptions struct {
-	FileToUpload   string
-	FollowLocation bool
-	MaxRedirect    int
-	ProfileNames   []string
-	RequestName    string
-	Request        Request
-	Variables      map[string]string
+	FileToUpload    string
+	FollowLocation  bool
+	MaxRedirect     int
+	PostProcessFile string
+	ProfileNames    []string
+	RequestName     string
+	Request         Request
+	Variables       map[string]string
 }

--- a/request/post_process.go
+++ b/request/post_process.go
@@ -1,0 +1,39 @@
+package request
+
+import (
+	"io/ioutil"
+
+	"github.com/robertkrimen/otto"
+)
+
+// PostProcess processes the executed requests using the post processing script
+func PostProcess(options *ExecutionOptions, executedRequests []ExecutedRequestResponse, responseErr error) error {
+	if options.PostProcessFile == "" {
+		return nil
+	}
+
+	sourceCode, readError := ioutil.ReadFile(options.PostProcessFile)
+	if readError != nil {
+		return readError
+	}
+
+	vm := otto.New()
+
+	script, compileErr := vm.Compile(options.PostProcessFile, sourceCode)
+	if compileErr != nil {
+		return compileErr
+	}
+
+	vm.Set("executed", executedRequests)
+	if len(executedRequests) > 0 {
+		vm.Set("request", executedRequests[0].Request)
+		vm.Set("response", executedRequests[0].Response)
+	}
+
+	_, executeError := vm.Run(script)
+	if executeError != nil {
+		return executeError
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds a post processing engine and command line option. A Javascript file can be passed in and will be processed using [otto](https://github.com/robertkrimen/otto).

For now, not much can be done. The executed requests are passed in to the script but all output is being redirected to the daemon log which makes it hard to get.