### PR TITLE
Add global session

### DIFF
--- a/cmd/go-http-daemon/main.go
+++ b/cmd/go-http-daemon/main.go
@@ -116,7 +116,10 @@ func setVariable(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	session.SetGlobalVariable(setVariableRequest.Name, setVariableRequest.Value)
+	for _, variable := range setVariableRequest.Values {
+		session.SetGlobalVariable(variable.Name, variable.Value)
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/cli/command_line_options.go
+++ b/pkg/cli/command_line_options.go
@@ -72,7 +72,21 @@ func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
 	result.OutputFile = outputFile
 	result.PostProcessFile = postProcessFile
 
-	url, requestName, profiles, values, urlError := parseArgs(commandLine.Args())
+	parsedVariables, variableError := parseValues(variables)
+	result.Variables = parsedVariables
+
+	if variableError != nil {
+		return result, variableError
+	}
+
+	cliArguments := commandLine.Args()
+
+	if len(cliArguments) == 0 && len(parsedVariables) > 0 {
+		// Want to set a variable value into the global context
+		return result, nil
+	}
+
+	url, requestName, profiles, values, urlError := parseArgs(cliArguments)
 	result.Profiles = profiles
 	result.RequestName = requestName
 	result.URL = url
@@ -87,13 +101,6 @@ func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
 
 	if headerError != nil {
 		return result, headerError
-	}
-
-	parsedVariables, variableError := parseValues(variables)
-	result.Variables = parsedVariables
-
-	if variableError != nil {
-		return result, variableError
 	}
 
 	return result, nil

--- a/pkg/model/key_value_pair.go
+++ b/pkg/model/key_value_pair.go
@@ -1,0 +1,7 @@
+package model
+
+// KeyValuePair represents a value associated with a key
+type KeyValuePair struct {
+	Name  string
+	Value string
+}

--- a/pkg/request/executor.go
+++ b/pkg/request/executor.go
@@ -125,7 +125,7 @@ func executeRequest(client *http.Client, configuredRequest Request, currentSessi
 	}
 
 	for _, cookie := range httpResponse.Cookies() {
-		currentSession.Cookies[cookie.Name] = cookie
+		session.SetCookie(currentSession.Host, cookie)
 	}
 
 	bodyBytes, readErr := ioutil.ReadAll(httpResponse.Body)

--- a/pkg/request/executor.go
+++ b/pkg/request/executor.go
@@ -125,7 +125,7 @@ func executeRequest(client *http.Client, configuredRequest Request, currentSessi
 	}
 
 	for _, cookie := range httpResponse.Cookies() {
-		currentSession.Cookies = append(currentSession.Cookies, cookie)
+		currentSession.Cookies[cookie.Name] = cookie
 	}
 
 	bodyBytes, readErr := ioutil.ReadAll(httpResponse.Body)

--- a/pkg/request/executor.go
+++ b/pkg/request/executor.go
@@ -154,7 +154,7 @@ func loadSessionForRequest(requestURL string) (*session.Session, error) {
 		return nil, parseURLErr
 	}
 
-	return session.Get(parsedURL.Hostname())
+	return session.Get(parsedURL.Hostname()), nil
 }
 
 func shouldRedirect(statusCode int) bool {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -5,21 +5,13 @@ import (
 	"sync"
 )
 
-var managerInstance = manager{
-	sessions: make(map[string]*Session),
-}
-
+var sessions = make(map[string]*Session)
 var sessionMutex = &sync.Mutex{}
 
-// manager holds sessions based on domain.
-type manager struct {
-	sessions map[string]*Session
-}
-
 // Get a session based on a URL.
-func Get(host string) (*Session, error) {
+func Get(host string) *Session {
 	sessionMutex.Lock()
-	session, exists := managerInstance.sessions[host]
+	session, exists := sessions[host]
 
 	if !exists {
 		session = &Session{
@@ -27,9 +19,9 @@ func Get(host string) (*Session, error) {
 			Variables: make(map[string]string),
 		}
 
-		managerInstance.sessions[host] = session
+		sessions[host] = session
 	}
 
 	sessionMutex.Unlock()
-	return session, nil
+	return session
 }

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -5,28 +5,57 @@ import (
 	"sync"
 )
 
-var sessions = make(map[string]*Session)
+var sessions = map[string]*Session{
+	// Global session
+	"": &Session{
+		Cookies:   make(map[string]*http.Cookie, 0),
+		Variables: make(map[string]string),
+	},
+}
+
 var sessionMutex = &sync.Mutex{}
 
 // Get a session based on a URL.
 func Get(host string) *Session {
+	session := ensureSession(host)
+
+	if host != "" {
+		mergedSession := mergeSessions(sessions[""], session)
+		mergedSession.Host = host
+		return mergedSession
+	}
+
+	return session
+}
+
+// SetCookie sets a cookie into a session, creating one if it doesn't exist
+func SetCookie(host string, cookie *http.Cookie) {
+	ensureSession(host).Cookies[cookie.Name] = cookie
+}
+
+// SetGlobalVariable sets a value that will be merged into all sessions
+func SetGlobalVariable(name, value string) {
+	sessions[""].Variables[name] = value
+}
+
+// SetVariable sets a value to a specific variable, creating a session if it doesn't exists
+func SetVariable(host, name, value string) {
+	ensureSession(host).Variables[name] = value
+}
+
+func ensureSession(host string) *Session {
 	sessionMutex.Lock()
+	defer sessionMutex.Unlock()
 
 	session, exists := sessions[host]
-
 	if !exists {
 		session = &Session{
 			Cookies:   make(map[string]*http.Cookie, 0),
+			Host:      host,
 			Variables: make(map[string]string),
 		}
 
 		sessions[host] = session
-	}
-
-	sessionMutex.Unlock()
-
-	if host != "" {
-		session = mergeSessions(session, Get(""))
 	}
 
 	return session

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -11,11 +11,12 @@ var sessionMutex = &sync.Mutex{}
 // Get a session based on a URL.
 func Get(host string) *Session {
 	sessionMutex.Lock()
+
 	session, exists := sessions[host]
 
 	if !exists {
 		session = &Session{
-			Cookies:   make([]*http.Cookie, 0),
+			Cookies:   make(map[string]*http.Cookie, 0),
 			Variables: make(map[string]string),
 		}
 
@@ -23,5 +24,28 @@ func Get(host string) *Session {
 	}
 
 	sessionMutex.Unlock()
+
+	if host != "" {
+		session = mergeSessions(session, Get(""))
+	}
+
 	return session
+}
+
+func mergeSessions(sessions ...*Session) *Session {
+	finalSession := &Session{
+		Cookies:   make(map[string]*http.Cookie, 0),
+		Variables: make(map[string]string),
+	}
+
+	for _, session := range sessions {
+		for n, v := range session.Cookies {
+			finalSession.Cookies[n] = v
+		}
+		for n, v := range session.Variables {
+			finalSession.Variables[n] = v
+		}
+	}
+
+	return finalSession
 }

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -35,12 +35,23 @@ func SetCookie(host string, cookie *http.Cookie) {
 
 // SetGlobalVariable sets a value that will be merged into all sessions
 func SetGlobalVariable(name, value string) {
+	if value == "" {
+		delete(sessions[""].Variables, name)
+		return
+	}
+
 	sessions[""].Variables[name] = value
 }
 
 // SetVariable sets a value to a specific variable, creating a session if it doesn't exists
 func SetVariable(host, name, value string) {
-	ensureSession(host).Variables[name] = value
+	session := ensureSession(host)
+	if value == "" {
+		delete(session.Variables, name)
+		return
+	}
+
+	session.Variables[name] = value
 }
 
 func ensureSession(host string) *Session {

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -7,21 +7,74 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPreserveCookie(t *testing.T) {
+func TestSessionManagement(t *testing.T) {
+	t.Run("Sets cookie correctly", testSetsCookie)
+	t.Run("Sets value correctly", testSetsValue)
+	t.Run("Sets value globally", testSetsValueGlobally)
+	t.Run("Sets value overrides global", testVariableOverridesGlobal)
+}
+
+func testSetsCookie(t *testing.T) {
 	sessionName := "test"
-	session := Get(sessionName)
 
 	cookie := &http.Cookie{
 		Name:  "Delicious",
 		Value: "Yes!",
 	}
 
-	session.Cookies["Delicious"] = cookie
+	SetCookie(sessionName, cookie)
 
-	session2 := Get(sessionName)
-	cookie2, exists := session2.Cookies[cookie.Name]
-	assert.True(t, exists, "Should keep cookie")
+	session := Get(sessionName)
+
+	assert.Equal(t, sessionName, session.Host, "Should have correct session name")
+
+	cookie2, exists := session.Cookies[cookie.Name]
+	assert.True(t, exists, "Should set cookie")
 	if exists {
 		assert.Equal(t, cookie2.Value, cookie.Value, "Should contain the same values")
+	}
+}
+
+func testSetsValue(t *testing.T) {
+	sessionName := "test"
+	variableName := "variable"
+	variableValue := "value"
+	SetVariable(sessionName, variableName, variableValue)
+
+	session := Get(sessionName)
+	value, exists := session.Variables[variableName]
+	assert.True(t, exists, "Should set variable")
+	if exists {
+		assert.Equal(t, variableValue, value, "Should have the correct value")
+	}
+}
+
+func testSetsValueGlobally(t *testing.T) {
+	sessionName := "test"
+	variableName := "variable"
+	variableValue := "value"
+	SetGlobalVariable(variableName, variableValue)
+
+	session := Get(sessionName)
+	value, exists := session.Variables[variableName]
+	assert.True(t, exists, "Should set variable to all sessions")
+	if exists {
+		assert.Equal(t, variableValue, value, "Should have the correct value")
+	}
+}
+
+func testVariableOverridesGlobal(t *testing.T) {
+	sessionName := "test"
+	variableName := "variable"
+	variableValue := "value"
+
+	SetGlobalVariable(variableName, "Global Value")
+	SetVariable(sessionName, variableName, variableValue)
+
+	session := Get(sessionName)
+	value, exists := session.Variables[variableName]
+	assert.True(t, exists, "Should set variable to all sessions")
+	if exists {
+		assert.Equal(t, variableValue, value, "Should have the correct value")
 	}
 }

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -1,0 +1,27 @@
+package session
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreserveCookie(t *testing.T) {
+	sessionName := "test"
+	session := Get(sessionName)
+
+	cookie := &http.Cookie{
+		Name:  "Delicious",
+		Value: "Yes!",
+	}
+
+	session.Cookies["Delicious"] = cookie
+
+	session2 := Get(sessionName)
+	cookie2, exists := session2.Cookies[cookie.Name]
+	assert.True(t, exists, "Should keep cookie")
+	if exists {
+		assert.Equal(t, cookie2.Value, cookie.Value, "Should contain the same values")
+	}
+}

--- a/pkg/session/models.go
+++ b/pkg/session/models.go
@@ -6,6 +6,6 @@ import (
 
 // Session stores information for one session
 type Session struct {
-	Cookies   []*http.Cookie
+	Cookies   map[string]*http.Cookie
 	Variables map[string]string
 }

--- a/pkg/session/models.go
+++ b/pkg/session/models.go
@@ -7,5 +7,6 @@ import (
 // Session stores information for one session
 type Session struct {
 	Cookies   map[string]*http.Cookie
+	Host      string
 	Variables map[string]string
 }

--- a/pkg/session/set_variable.go
+++ b/pkg/session/set_variable.go
@@ -1,0 +1,7 @@
+package session
+
+// SetVariableRequest is used to request a variable to be set
+type SetVariableRequest struct {
+	Name  string
+	Value string
+}

--- a/pkg/session/set_variable.go
+++ b/pkg/session/set_variable.go
@@ -1,7 +1,8 @@
 package session
 
+import "github.com/visola/go-http-cli/pkg/model"
+
 // SetVariableRequest is used to request a variable to be set
 type SetVariableRequest struct {
-	Name  string
-	Value string
+	Values []model.KeyValuePair
 }

--- a/test/integration/assertions.go
+++ b/test/integration/assertions.go
@@ -12,6 +12,19 @@ func HasBody(t *testing.T, req Request, body string) {
 	assert.Equal(t, body, req.Body, "Should match body")
 }
 
+// HasCookie asserts that the request received the specific cookies
+func HasCookie(t *testing.T, req Request, name string, value string) {
+	assert.True(t, len(req.Cookies) > 0, "Request does not contain any cookies.")
+	if len(req.Cookies) > 0 {
+		for _, cookie := range req.Cookies {
+			if cookie.Name == name && cookie.Value == value {
+				return
+			}
+		}
+		assert.Fail(t, fmt.Sprintf("Cookies do not contain %s=%s => %s", name, value, req.Cookies))
+	}
+}
+
 // HasHeader asserts that the rquest received the specified header with value
 func HasHeader(t *testing.T, req Request, name string, value string) {
 	checkMapOfArrayOfStrings(t, req.Headers, name, value, "header")

--- a/test/integration/cookies_test.go
+++ b/test/integration/cookies_test.go
@@ -23,5 +23,6 @@ func testKeepsTrackOfCookies(t *testing.T) {
 
 	RunHTTP(t, testServer.URL)
 	HasMethod(t, lastRequest, http.MethodGet)
-	HasHeader(t, lastRequest, "Cookie", "someKey=someValue; anotherCookie=someOtherValue")
+	HasCookie(t, lastRequest, "someKey", "someValue")
+	HasCookie(t, lastRequest, "anotherCookie", "someOtherValue")
 }

--- a/test/integration/global_variables_test.go
+++ b/test/integration/global_variables_test.go
@@ -1,0 +1,42 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGlobalVariables(t *testing.T) {
+	t.Run("Can override global variables", WrapForIntegrationTest(testCanOverrideGlobalVariable))
+	t.Run("Setting global variable works", WrapForIntegrationTest(testSetGlobalVariableWorks))
+}
+
+func testCanOverrideGlobalVariable(t *testing.T) {
+	RunHTTP(t,
+		"-V", "var1=value1",
+	)
+
+	RunHTTP(t,
+		testServer.URL,
+		"-X", "POST",
+		"-V", "var1=value2",
+		"name={var1}",
+	)
+
+	HasMethod(t, lastRequest, http.MethodPost)
+	HasBody(t, lastRequest, `{"name":"value2"}`)
+}
+
+func testSetGlobalVariableWorks(t *testing.T) {
+	RunHTTP(t,
+		"-V", "var1=value1",
+	)
+
+	RunHTTP(t,
+		testServer.URL,
+		"-X", "POST",
+		"name={var1}",
+	)
+
+	HasMethod(t, lastRequest, http.MethodPost)
+	HasBody(t, lastRequest, `{"name":"value1"}`)
+}

--- a/test/integration/test_server.go
+++ b/test/integration/test_server.go
@@ -10,6 +10,7 @@ import (
 // Request stores a request that was received by the test server
 type Request struct {
 	Body    string
+	Cookies []*http.Cookie
 	Headers map[string][]string
 	Method  string
 	Path    string
@@ -37,6 +38,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	lastRequest = Request{
 		Body:    string(body),
+		Cookies: r.Cookies(),
 		Headers: r.Header,
 		Method:  r.Method,
 		Path:    r.URL.Path,


### PR DESCRIPTION
This PR includes:
- Some refactoring to simplify session management
- Adds a global session that gets merged to all other sessions
- Adds unit tests to cover the above
- Adds a daemon endpoint to set global variables
- Change http CLI to support only setting a variable and not actually make any request
- Fixes #76.
- Also fixes the cookie flaky test by adding a HasCookie assertion