### PR TITLE
Extend post processing capabilities

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -158,8 +158,9 @@ func printOutput(requestExecution *daemon.RequestExecution, options *cli.Command
 		}
 
 		if requestResponse.PostProcessOutput != "" {
-			fmt.Println("\n -- Post processing output --")
-			fmt.Println(requestResponse.PostProcessOutput)
+			postProcessColor := color.New(color.FgBlue).PrintfFunc()
+			postProcessColor("\n -- Post processing output --")
+			postProcessColor("\n%s\n", requestResponse.PostProcessOutput)
 		}
 
 		if requestResponse.PostProcessError != "" {

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -146,6 +146,8 @@ func parseCommandLineArguments() *cli.CommandLineOptions {
 
 func printOutput(requestExecution *daemon.RequestExecution, options *cli.CommandLineOptions) {
 	exitCode := 0
+	postProcessOutput := ""
+	postProcessError := ""
 	for _, requestResponse := range requestExecution.RequestResponses {
 		output.PrintRequest(requestResponse.Request)
 		fmt.Println("")
@@ -158,15 +160,24 @@ func printOutput(requestExecution *daemon.RequestExecution, options *cli.Command
 		}
 
 		if requestResponse.PostProcessOutput != "" {
-			postProcessColor := color.New(color.FgBlue).PrintfFunc()
-			postProcessColor("\n -- Post processing output --")
-			postProcessColor("\n%s\n", requestResponse.PostProcessOutput)
+			postProcessOutput = requestResponse.PostProcessOutput
 		}
 
 		if requestResponse.PostProcessError != "" {
-			color.Red("Error post processing request: %s", requestResponse.PostProcessError)
-			exitCode = 30
+			postProcessError = requestResponse.PostProcessError
 		}
+	}
+
+	if postProcessOutput != "" {
+		postProcessColor := color.New(color.FgBlue).PrintfFunc()
+		postProcessColor("\n-- Post processing output --")
+		postProcessColor("\n%s", postProcessOutput)
+		postProcessColor("\n-- End of output --\n")
+	}
+
+	if postProcessError != "" {
+		color.Red("Error post processing request: %s", postProcessError)
+		exitCode = 30
 	}
 
 	if requestExecution.ErrorMessage != "" {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gorilla/mux v1.6.2
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRU
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
+github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/request/executor.go
+++ b/pkg/request/executor.go
@@ -31,7 +31,9 @@ func ExecuteRequestLoop(executionContext ExecutionContext) ([]ExecutedRequestRes
 	requestsToExecute := []Request{executionContext.Request}
 	result := make([]ExecutedRequestResponse, 0)
 	redirectCount := 0
+	requestCount := 0
 	for {
+		requestCount++
 		currentConfiguredRequest := requestsToExecute[0]
 		requestsToExecute = requestsToExecute[1:]
 
@@ -58,10 +60,16 @@ func ExecuteRequestLoop(executionContext ExecutionContext) ([]ExecutedRequestRes
 		}
 		result = append(result, requestResponse)
 
-		postProcessOutput, postProcessError := PostProcess(&executionContext, result, executeErr)
-		result[len(result)-1].PostProcessOutput = postProcessOutput
-		if postProcessError != nil {
-			result[len(result)-1].PostProcessError = postProcessError.Error()
+		if requestCount == 1 {
+			postProcessResult, postProcessError := PostProcess(&executionContext, result, executeErr)
+			result[len(result)-1].PostProcessOutput = postProcessResult.Output
+			if postProcessError != nil {
+				result[len(result)-1].PostProcessError = postProcessError.Error()
+			}
+
+			if len(postProcessResult.Requests) > 0 {
+				requestsToExecute = append(requestsToExecute, postProcessResult.Requests...)
+			}
 		}
 
 		if executeErr != nil {

--- a/pkg/request/post_process.go
+++ b/pkg/request/post_process.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 
 	"github.com/robertkrimen/otto"
+	"github.com/visola/go-http-cli/pkg/session"
 )
 
 // PostProcessContext stores
 type PostProcessContext struct {
-	Output string
+	Output   string
+	Requests []Request
 }
 
 // PostProcessSourceCode represents the source code to be executed
@@ -21,32 +23,42 @@ type PostProcessSourceCode struct {
 }
 
 // PostProcess processes the executed requests using the post processing script
-func PostProcess(executionContext *ExecutionContext, executedRequests []ExecutedRequestResponse, responseErr error) (string, error) {
+func PostProcess(executionContext *ExecutionContext, executedRequests []ExecutedRequestResponse, responseErr error) (*PostProcessContext, error) {
 	sourceCode := executionContext.PostProcessCode
 	if sourceCode.SourceCode == "" {
-		return "", nil
+		return &PostProcessContext{}, nil
 	}
 
 	vm := otto.New()
 
 	script, compileErr := vm.Compile(sourceCode.SourceFilePath, sourceCode.SourceCode)
 	if compileErr != nil {
-		return "", compileErr
+		return &PostProcessContext{}, compileErr
 	}
 
 	context := preparePostProcessContext(vm, executionContext, executedRequests, responseErr)
 
 	_, executeError := vm.Run(script)
 	if executeError != nil {
-		return "", executeError
+		return &PostProcessContext{}, executeError
 	}
 
-	return context.Output, nil
+	return context, nil
 }
 
 func createAddVariableFunction(executionContext *ExecutionContext) func(string, string) {
 	return func(name string, value string) {
-		executionContext.Session.Variables[name] = value
+		session.SetVariable(executionContext.Session.Host, name, value)
+	}
+}
+
+func createAddRequestFunction(context *PostProcessContext) func(otto.Value) {
+	return func(value otto.Value) {
+		if value.IsString() {
+			context.Requests = append(context.Requests, Request{
+				URL: otto.Value.String(value),
+			})
+		}
 	}
 }
 
@@ -64,10 +76,12 @@ func createPrintlnFunction(context *PostProcessContext) func(...interface{}) {
 
 func preparePostProcessContext(vm *otto.Otto, executionContext *ExecutionContext, executedRequests []ExecutedRequestResponse, responseErr error) *PostProcessContext {
 	context := &PostProcessContext{
-		Output: "",
+		Output:   "",
+		Requests: make([]Request, 0),
 	}
 
 	vm.Set("addVariable", createAddVariableFunction(executionContext))
+	vm.Set("addRequest", createAddRequestFunction(context))
 	vm.Set("print", createPrintFunction(context))
 	vm.Set("println", createPrintlnFunction(context))
 

--- a/test/integration/assertions.go
+++ b/test/integration/assertions.go
@@ -41,6 +41,13 @@ func HasPath(t *testing.T, req Request, expectedPath string) {
 	assert.Equal(t, expectedPath, req.Path, "Should match path")
 }
 
+// HasRequestCount checks if the number of requests executed so far is the expected
+func HasRequestCount(t *testing.T, expectedCount int) {
+	if len(allRequests) != expectedCount {
+		t.Fatalf("Should have executed %d requests, but count is %d", expectedCount, len(allRequests))
+	}
+}
+
 // HasQueryParam checks if a request has the query parameter with the specified value
 func HasQueryParam(t *testing.T, req Request, name string, value string) {
 	checkMapOfArrayOfStrings(t, req.Query, name, value, "query param")

--- a/test/integration/post_process_test.go
+++ b/test/integration/post_process_test.go
@@ -1,15 +1,84 @@
 package integration
 
 import (
+	"net/http"
 	"os"
 	"testing"
 )
 
 func TestPostProcess(t *testing.T) {
-	t.Run("Can set variable", WrapForIntegrationTest(testCanSetVariableFromScript))
+	t.Run("Add request as object", WrapForIntegrationTest(testAddRequestAsObjectFromScript))
+	t.Run("Add request by name", WrapForIntegrationTest(testAddRequestByNameFromScript))
+	t.Run("Add request by URL", WrapForIntegrationTest(testAddRequestByURLFromScript))
+	t.Run("Set variable", WrapForIntegrationTest(testSetVariableFromScript))
 }
 
-func testCanSetVariableFromScript(t *testing.T) {
+func testAddRequestAsObjectFromScript(t *testing.T) {
+	CreateProfile("test", `
+baseURL: '{test-server}'
+
+variables:
+  companyId: 1234
+`)
+
+	postProcessScript := `
+		addRequest({
+			Body: '{"name":"Some Company"}',
+			Method: 'POST',
+			URL: '/companies/{companyId}',
+		});
+	`
+
+	WithTempFile(t, postProcessScript, func (tempFile *os.File) {
+		RunHTTP(t, "+test", "--post-process", tempFile.Name(), testServer.URL+"/hello")
+
+		HasRequestCount(t, 2)
+		HasBody(t, allRequests[1], `{"name":"Some Company"}`)
+		HasMethod(t, allRequests[1], http.MethodPost)
+		HasPath(t, allRequests[1], "/companies/1234")
+	})
+}
+
+func testAddRequestByNameFromScript(t *testing.T) {
+	CreateProfile("test", `
+baseURL: '{test-server}'
+
+requests:
+  someRequest:
+    body: 'Some Request'
+    method: POST
+    url: /some/place
+`)
+
+	postProcessScript := "addRequest('@someRequest');"
+	WithTempFile(t, postProcessScript, func (tempFile *os.File) {
+		RunHTTP(t, "+test", "--post-process", tempFile.Name(), testServer.URL+"/hello")
+
+		HasRequestCount(t, 2)
+		HasBody(t, allRequests[1], "Some Request")
+		HasMethod(t, allRequests[1], http.MethodPost)
+		HasPath(t, allRequests[1], "/some/place")
+	})
+}
+
+func testAddRequestByURLFromScript(t *testing.T) {
+	CreateProfile("test", `
+baseURL: '{test-server}'
+
+variables:
+  companyId: 1234
+`)
+
+	postProcessScript := "addRequest('/companies/{companyId}');"
+	WithTempFile(t, postProcessScript, func (tempFile *os.File) {
+		RunHTTP(t, "+test", "--post-process", tempFile.Name(), testServer.URL+"/hello")
+
+		HasRequestCount(t, 2)
+		HasPath(t, allRequests[1], "/companies/1234")
+	})
+}
+
+func testSetVariableFromScript(t *testing.T) {
 	// Post process will get token from body, after parsing JSON
 	postProcessScript := `
 		var body = JSON.parse(response.Body);

--- a/test/integration/post_process_test.go
+++ b/test/integration/post_process_test.go
@@ -1,0 +1,36 @@
+package integration
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPostProcess(t *testing.T) {
+	t.Run("Can set variable", WrapForIntegrationTest(testCanSetVariableFromScript))
+}
+
+func testCanSetVariableFromScript(t *testing.T) {
+	// Post process will get token from body, after parsing JSON
+	postProcessScript := `
+		var body = JSON.parse(response.Body);
+		addVariable('token', body.token);
+	`
+	
+	WithTempFile(t, postProcessScript, func (tempFile *os.File) {
+		// Set reply body
+		token := "not-real-token"
+		replyWith := ReplyWith{
+			Body: `{"token":"`+token+`"}`,
+		}
+		prepareReply(replyWith)
+	
+		// Run "login" and post process response
+		RunHTTP(t, "-X", "POST", "--post-process", tempFile.Name(), testServer.URL+"/login")
+	
+		// Second request uses the token from post process
+		RunHTTP(t, "-H", "Authorization: Bearer {token}", testServer.URL+"/dashboard")
+	
+		// Check that the header was set to the correct value
+		HasHeader(t, lastRequest, "Authorization", "Bearer "+token)
+	})
+}

--- a/test/integration/test_server.go
+++ b/test/integration/test_server.go
@@ -21,13 +21,19 @@ type Request struct {
 // ReplyWith gives specifications the ability to ask the server to reply in a specific way
 type ReplyWith struct {
 	Headers map[string][]string
+	Body string
 }
 
+const defaultBody = "Hello world!"
+
+var allRequests = make([]Request, 0)
 var lastRequest Request
-var replyWith ReplyWith
 var testServer *httptest.Server
 
+var replyWith = defaultReplyWith()
+
 func startTestServer() {
+	allRequests = make([]Request, 0)
 	testServer = httptest.NewServer(http.HandlerFunc(handleRequest))
 }
 
@@ -46,6 +52,8 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		Query:   r.URL.Query(),
 	}
 
+	allRequests = append(allRequests, lastRequest)
+
 	for header, values := range replyWith.Headers {
 		for _, value := range values {
 			w.Header().Add(header, value)
@@ -53,11 +61,16 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO - Store request received
-	// TODO - Return something useful
-	fmt.Fprintln(w, "Hello world!")
+	fmt.Fprintln(w, replyWith.Body);
 
 	// Clean up reply with after finished
-	replyWith = ReplyWith{}
+	replyWith = defaultReplyWith()
+}
+
+func defaultReplyWith() ReplyWith {
+	return ReplyWith{
+		Body: defaultBody,
+	}
 }
 
 func prepareReply(r ReplyWith) {

--- a/test/integration/wrappers.go
+++ b/test/integration/wrappers.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -8,6 +9,22 @@ import (
 	"strings"
 	"testing"
 )
+
+// WithTempFile creates a temporary file, write content to it and then call the wrapped function
+func WithTempFile(t *testing.T, content string, toWrap func(*os.File)) {
+	tempFile, err := ioutil.TempFile("", "script.js")
+	if err != nil {
+		t.Fatalf("Error while creating temp file: %s", err)
+	}
+
+	defer os.Remove(tempFile.Name())
+
+	if _, err := tempFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Error while writing content to temp file: %s", err)
+	}
+
+	toWrap(tempFile)
+}
 
 // WrapForIntegrationTest wraps a testing function with all the required pieces for an integration test
 func WrapForIntegrationTest(toWrap func(*testing.T)) func(*testing.T) {


### PR DESCRIPTION
Solves a big chunk of #77.

This PR adds `addRequest` function to post processing script context. This function can be used to add a request to the execution context using one of the following arguments:
- 'string' - Will be used as an URL
- 'string' starting with `@` - Will try to load as a named request
- 'object' - Will be mapped to a `Request` object

All three of the above will be configured using the current execution context. That means all profiles will be loaded and all variables will be applied. Exactly as the context passed to the first request started from the command line.