### PR TITLE
Allow insecure http requests

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -47,6 +47,7 @@ func main() {
 	configuredRequest.PostProcessCode = loadPostProcessScript(options, mergedProfile)
 
 	executionContext := request.ExecutionContext{
+		AllowInsecure:    options.AllowInsecure,
 		FollowLocation:   options.FollowLocation,
 		MaxAddedRequests: options.MaxAddedRequests,
 		MaxRedirect:      options.MaxRedirect,

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/pkg/base/interfaces.go
+++ b/pkg/base/interfaces.go
@@ -1,5 +1,10 @@
 package base
 
+// WithBody is something that has a configuration to allow insecure HTTP connections
+type WithAllowInsecure interface {
+	GetAllowInsecure() bool
+}
+
 // WithBody is something that has a body
 type WithBody interface {
 	GetBody() (string, error)

--- a/pkg/cli/command_line_options.go
+++ b/pkg/cli/command_line_options.go
@@ -11,6 +11,7 @@ import (
 
 // CommandLineOptions stores information that was requested by the user from the CLI.
 type CommandLineOptions struct {
+	AllowInsecure    bool
 	Body             string
 	Headers          map[string][]string
 	FollowLocation   bool
@@ -46,13 +47,14 @@ func (i *keyValuePair) Type() string {
 func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
 	var body, fileToUpload, method, outputFile, postProcessFile string
 	var configPaths, headers, variables keyValuePair
-	var followLocation bool
+	var allowInsecure, followLocation bool
 
 	commandLine := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	commandLine.VarP(&configPaths, "config", "c", "Path to configuration files to be used")
 	commandLine.StringVarP(&body, "data", "d", "", "Data to be sent as body")
 	commandLine.VarP(&headers, "header", "H", "Headers to include with your request")
+	commandLine.BoolVarP(&allowInsecure, "insecure", "k", false, "Allow connections with sites that have invalid SSL/TLS information")
 	commandLine.BoolVarP(&followLocation, "location", "L", false, "Automatically follow redirects")
 	maxAddedRequests := commandLine.Int("max-added-requests", 10, "Maximum number of requests to add")
 	maxRedirect := commandLine.Int("max-redirs", 10, "Maximum number of redirects to follow")
@@ -66,6 +68,7 @@ func ParseCommandLineOptions(args []string) (*CommandLineOptions, error) {
 
 	result := new(CommandLineOptions)
 
+	result.AllowInsecure = allowInsecure
 	result.Body = body
 	result.FileToUpload = fileToUpload
 	result.FollowLocation = followLocation

--- a/pkg/profile/named_request.go
+++ b/pkg/profile/named_request.go
@@ -7,6 +7,7 @@ import (
 
 // NamedRequest is a representation of a request that can be loaded from a profile.
 type NamedRequest struct {
+	AllowInsecure     bool
 	Body              string
 	FileToUpload      string
 	Headers           map[string][]string
@@ -16,6 +17,11 @@ type NamedRequest struct {
 	Source            string // File where this request was loaded from
 	URL               string
 	Values            map[string][]string
+}
+
+// GetAllowInsecure returns if this named request allow insecure HTTP connections
+func (req NamedRequest) GetAllowInsecure() bool {
+	return req.AllowInsecure
 }
 
 // GetBody returns the body for this NamedRequest

--- a/pkg/profile/options.go
+++ b/pkg/profile/options.go
@@ -2,10 +2,16 @@ package profile
 
 // Options that can come from a profile file.
 type Options struct {
-	BaseURL      string
-	Headers      map[string][]string
-	NamedRequest map[string]NamedRequest
-	Variables    map[string]string
+	AllowInsecure bool
+	BaseURL       string
+	Headers       map[string][]string
+	NamedRequest  map[string]NamedRequest
+	Variables     map[string]string
+}
+
+// GetAllowInsecure returns if this option allow insecure HTTP connections
+func (ops Options) GetAllowInsecure() bool {
+	return ops.AllowInsecure
 }
 
 // GetHeaders returns the headers set in this option
@@ -17,6 +23,7 @@ func (ops Options) GetHeaders() map[string][]string {
 func MergeOptions(profiles []Options) Options {
 	baseURL := ""
 	headers := make(map[string][]string)
+	insecure := false
 	requests := make(map[string]NamedRequest)
 	variables := make(map[string]string)
 
@@ -25,6 +32,8 @@ func MergeOptions(profiles []Options) Options {
 		if profile.BaseURL != "" {
 			baseURL = profile.BaseURL
 		}
+
+		insecure = insecure || profile.AllowInsecure
 
 		for header, values := range profile.Headers {
 			headers[header] = append(headers[header], values...)
@@ -40,9 +49,10 @@ func MergeOptions(profiles []Options) Options {
 	}
 
 	return Options{
-		BaseURL:      baseURL,
-		Headers:      headers,
-		NamedRequest: requests,
-		Variables:    variables,
+		AllowInsecure: insecure,
+		BaseURL:       baseURL,
+		Headers:       headers,
+		NamedRequest:  requests,
+		Variables:     variables,
 	}
 }

--- a/pkg/profile/yaml_profile_format.go
+++ b/pkg/profile/yaml_profile_format.go
@@ -10,6 +10,7 @@ type yamlProfileFormat struct {
 	Auth      authConfiguration `yaml:"auth"`
 	BaseURL   string            `yaml:"baseURL"`
 	Headers   map[string]model.ArrayOrString
+	Insecure  bool
 	Import    model.ArrayOrString `yaml:"import"`
 	Requests  map[string]requestConfiguration
 	Variables map[string]string
@@ -28,6 +29,7 @@ type requestConfiguration struct {
 	Body              string
 	FileToUpload      string `yaml:"fileToUpload"`
 	Headers           map[string]model.ArrayOrString
+	Insecure          bool
 	Method            string
 	PostProcessScript string `yaml:"postProcessScript"`
 	URL               string
@@ -42,10 +44,11 @@ func (loadedProfile yamlProfileFormat) toOptions() (*Options, error) {
 	}
 
 	return &Options{
-		BaseURL:      loadedProfile.BaseURL,
-		Headers:      headers,
-		NamedRequest: toMapOfNamedRequest(loadedProfile.Requests),
-		Variables:    loadedProfile.Variables,
+		AllowInsecure: loadedProfile.Insecure,
+		BaseURL:       loadedProfile.BaseURL,
+		Headers:       headers,
+		NamedRequest:  toMapOfNamedRequest(loadedProfile.Requests),
+		Variables:     loadedProfile.Variables,
 	}, nil
 }
 
@@ -76,6 +79,7 @@ func toMapOfNamedRequest(requestConfigurations map[string]requestConfiguration) 
 	result := make(map[string]NamedRequest)
 	for name, requestConfiguration := range requestConfigurations {
 		result[name] = NamedRequest{
+			AllowInsecure:     requestConfiguration.Insecure,
 			Body:              requestConfiguration.Body,
 			FileToUpload:      requestConfiguration.FileToUpload,
 			Headers:           model.ToMapOfArrayOfStrings(requestConfiguration.Headers),

--- a/pkg/request/execution_context.go
+++ b/pkg/request/execution_context.go
@@ -4,6 +4,7 @@ import "github.com/visola/go-http-cli/pkg/session"
 
 // ExecutionContext represent the options to be passed for the request executor.
 type ExecutionContext struct {
+	AllowInsecure    bool
 	FollowLocation   bool
 	MaxAddedRequests int
 	MaxRedirect      int

--- a/pkg/request/executor.go
+++ b/pkg/request/executor.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -41,6 +42,10 @@ func ExecuteRequestLoop(executionContext ExecutionContext) ([]ExecutedRequestRes
 		currentConfiguredRequest, replaceVariablesError := replaceRequestVariables(currentConfiguredRequest, mergedProfiles, executionContext)
 		if replaceVariablesError != nil {
 			return nil, replaceVariablesError
+		}
+
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: executionContext.AllowInsecure || currentConfiguredRequest.AllowInsecure},
 		}
 
 		response, executeErr := executeRequest(client, currentConfiguredRequest, executionContext.Session)

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -11,6 +11,7 @@ import (
 
 // Request stores data required to configure a request to be executed
 type Request struct {
+	AllowInsecure   bool
 	Body            string
 	Cookies         []*http.Cookie
 	Headers         map[string][]string
@@ -18,6 +19,11 @@ type Request struct {
 	PostProcessCode PostProcessSourceCode
 	QueryParams     map[string][]string
 	URL             string
+}
+
+// GetAllowInsecure returns if this named request allow insecure HTTP connections
+func (req Request) GetAllowInsecure() bool {
+	return req.AllowInsecure
 }
 
 // GetBody returns the body for this request
@@ -62,6 +68,10 @@ func (req *Request) Merge(toMerge interface{}) error {
 			return err
 		}
 		req.MergeBody(body)
+	}
+
+	if withAllowInsecure, ok := toMerge.(base.WithAllowInsecure); ok {
+		req.AllowInsecure = req.AllowInsecure || withAllowInsecure.GetAllowInsecure()
 	}
 
 	if withHeader, ok := toMerge.(base.WithHeaders); ok {


### PR DESCRIPTION
## In this PR

Initial implementation for #141.
- Allow insecure requests using command line argument `-k` or `--insecure`
- Allow insecure requests using `insecure` from profiles
- Allow insecure requests using `insecure` from named requests