### PR TITLE
Fix post processing script from named request

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -44,7 +44,10 @@ func main() {
 		panic(configureError)
 	}
 
-	configuredRequest.PostProcessCode = loadPostProcessScript(options, mergedProfile)
+	loadedPostProcessScript := loadPostProcessScript(options, mergedProfile)
+	if loadedPostProcessScript.SourceCode != "" {
+		configuredRequest.PostProcessCode = loadedPostProcessScript
+	}
 
 	executionContext := request.ExecutionContext{
 		AllowInsecure:    options.AllowInsecure,


### PR DESCRIPTION
### What's in this PR?

- Fix executing the attribute `postProcessScript` from a named request
  - It wasn't executing the post process script passed in from a profile
- Add an integration test for it

### How did I test it?

- Added an integration test