### PR TITLE
Update to go 1 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.21
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/test/integration/execute_command.go
+++ b/test/integration/execute_command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"syscall"
 	"testing"
 
@@ -19,8 +20,18 @@ func ExecuteCommand(cmd string, args ...string) (int, string, string, error) {
 	command := exec.Command(cmd, args...)
 	command.Dir = executionDir
 
+	dirname, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	currentUser, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
 	profilesDir, _ := profile.GetProfilesDir()
-	env := []string{"PATH=" + executionDir, "GO_HTTP_PROFILES=" + profilesDir}
+	env := []string{"PATH=" + executionDir, "GO_HTTP_PROFILES=" + profilesDir, "HOME=" + dirname, "USER=" + currentUser.Username}
 	command.Env = env
 
 	var outbuf, errbuf bytes.Buffer

--- a/test/integration/profiles.go
+++ b/test/integration/profiles.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -22,5 +21,5 @@ func CreateProfile(name string, content string) {
 	}
 
 	content = variables.ReplaceVariables(content, getContext())
-	ioutil.WriteFile(path.Join(profilesDir, name+".yml"), []byte(content), 0777)
+	os.WriteFile(path.Join(profilesDir, name+".yml"), []byte(content), 0777)
 }


### PR DESCRIPTION
### What was done?

- Create the env for executing commands in integration tests correctly
- Remove deprecated call to `ioutils.WriteFile`
- Update build script to use Go 1.21